### PR TITLE
copy ronin address to clipboard.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3514,6 +3514,16 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "clipboard": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
+      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "clipboardy": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
@@ -4813,6 +4823,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -6583,6 +6598,14 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         }
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -11326,6 +11349,11 @@
         "ajv-keywords": "^3.4.1"
       }
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -12463,6 +12491,11 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "tmp": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
@@ -12996,6 +13029,14 @@
       "resolved": "https://registry.npmjs.org/vue-cli-plugin-bootstrap-vue/-/vue-cli-plugin-bootstrap-vue-0.6.0.tgz",
       "integrity": "sha512-sgW3hPlD26AHGJSCoPmEeF1l3KeB/r18nfOAq9RkhIZx5hEwV4jZuiBCxdiyOsha0L5PiegKoofA4gn4c0eLcQ==",
       "dev": true
+    },
+    "vue-clipboard2": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/vue-clipboard2/-/vue-clipboard2-0.3.3.tgz",
+      "integrity": "sha512-aNWXIL2DKgJyY/1OOeITwAQz1fHaCIGvUFHf9h8UcoQBG5a74MkdhS/xqoYe7DNZdQmZRL+TAdIbtUs9OyVjbw==",
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
     },
     "vue-eslint-parser": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "vue": "^2.6.10",
     "vue-chartjs": "^3.5.1",
     "vue-chartkick": "^0.6.1",
+    "vue-clipboard2": "^0.3.3",
     "vue-graph": "^0.9.0",
     "vue-router": "^3.0.3",
     "vue2-dropzone": "^3.6.0",

--- a/src/components/ScholarBlock.vue
+++ b/src/components/ScholarBlock.vue
@@ -29,13 +29,27 @@
         </b-col>
         <b-col cols="2">
             {{truncatedAddress}}
-        <b-icon-clipboard v-b-tooltip.hover :title="getHoverTip" @click="copyRonin" @mouseleave="copied=false">
-        </b-icon-clipboard>
+            <b-button
+                    size="sm"
+                    v-b-tooltip.hover
+                    :title="getHoverTip"
+                    @mouseleave="copied=false"
+                    v-clipboard:copy="scholar.address"
+                    v-clipboard:success="copyRonin">
+                <b-icon-clipboard></b-icon-clipboard>
+            </b-button>
         </b-col>
         <b-col cols="2">
             {{truncatedPersonalAddress}}
-            <b-icon-clipboard v-b-tooltip.hover :title="getHoverTip" @click="copyPersonalRonin" @mouseleave="copied=false">
-            </b-icon-clipboard>
+            <b-button
+                    size="sm"
+                    v-b-tooltip.hover
+                    :title="getHoverTip"
+                    @mouseleave="copied=false"
+                    v-clipboard:copy="scholar.personal_address"
+                    v-clipboard:success="copyPersonalRonin">
+                <b-icon-clipboard></b-icon-clipboard>
+            </b-button>
         </b-col>
         <b-col cols="1">
             NULL
@@ -148,10 +162,10 @@ export default {
             return this.scholarSnapshotData[0]
         },
         truncatedAddress(){
-            return "..."+this.scholar.address.slice(-8)
+            return this.scholar.address.slice(0,10) + "... " +this.scholar.address.slice(-4)
         },
         truncatedPersonalAddress(){
-            return "..."+this.scholar.personal_address.slice(-8)
+            return this.scholar.personal_address.slice(0,10) + "... " +this.scholar.personal_address.slice(-4)
         },
         getHoverTip(){
             return this.copied ? "Copied!" : "Copy to Clipboard"


### PR DESCRIPTION
**Features Implemented**
- Icon is now a button that copies the targeted ronin address to the clipboard
- Ronin address is displayed in the same shorthand form as the Ronin wallet Chrome extension

![copyToClipboard](https://user-images.githubusercontent.com/33329945/134751993-46ad781f-4562-4c4b-98e2-79bb83161c37.gif)

